### PR TITLE
Embed frontend with all syntax

### DIFF
--- a/main.tmpl.go
+++ b/main.tmpl.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options/windows"
 )
 
-//go:embed frontend/out/* frontend/out/_next/static/*/* frontend/out/_next/static/*/*/*
+//go:embed all:frontend/out frontend/out/_next/static/*/* frontend/out/_next/static/*/*/*
 var assets embed.FS
 
 //go:embed build/appicon.png


### PR DESCRIPTION
Changes the `assets` embed to use `all:frontend/out` instead of `frontend/out/*` to prevent the error described in #1. Fix recommended by @siddmo.